### PR TITLE
Fix GEOJSONENCODE command (and really enable GEOMETRYFILTER subcommand).

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Encodes the reply of GEO commands as a GeoJSON object. Valid GEO commands are:
 * [`GEOHASH`]
 * [`GEOPOS`]
 * [`GEORADIUS`] and [`GEORADIUSBYMEMBER`]
+* [`GEOMETRYFILTER`]
 
 **Return:** String, specifically the reply of the GEO command encoded as a GeoJSON object.
 


### PR DESCRIPTION
GEOJSONENCODE command with GEOMETRYFILTER subcommand is broken. It still refers to GEOPOLYGON name, and currently doesn't work anyway due to missing geomash key reference.
